### PR TITLE
fix: horizontalHeaderSeparatorBuilder same width as rows

### DIFF
--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -261,7 +261,7 @@ class _GridState extends State<Grid> {
     resortBySortedColumn();
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         GridColumnHeader(
           physics: widget.physics,
@@ -271,7 +271,11 @@ class _GridState extends State<Grid> {
           indices: indices,
           scrollController: columnHeaderController,
         ),
-        widget.horizontalHeaderSeparatorBuilder(context),
+        SizedBox(
+          width: calculateColumnWidths(indices)
+              .reduce((value, element) => value + element),
+          child: widget.horizontalHeaderSeparatorBuilder(context),
+        ),
         Expanded(
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,


### PR DESCRIPTION
Currently there is an issue in which `horizontalHeaderSeparatorBuilder` is as wide as the screen instead of being as wide as the row:

![Bildschirmfoto 2022-11-01 um 14 55 59](https://user-images.githubusercontent.com/13286425/199251389-a946f720-8445-427f-9fb5-e67537e6b787.png)

The width of the builder can be constrained, while there does not seem to be any side-effect to use `start` instead of `stetch` for cross alignment on the column:

![Bildschirmfoto 2022-11-01 um 14 56 05](https://user-images.githubusercontent.com/13286425/199251421-7c48d4da-5869-4283-bafe-654b58dd2024.png)
