### PR TITLE
fix: Invoke callbacks on complete row, not just content

### DIFF
--- a/lib/src/components.dart
+++ b/lib/src/components.dart
@@ -27,6 +27,9 @@ class GridRowHeader extends StatelessWidget {
         controller: scrollController,
         itemCount: rows.length,
         itemBuilder: (context, index) => GestureDetector(
+          // Instead of limiting the click area to child's clickable area,
+          // use complete area of widget
+          behavior: HitTestBehavior.opaque,
           onTap: rows[index].onTap?.call,
           onLongPress: rows[index].onLongPress?.call,
           child: SizedBox(
@@ -158,6 +161,9 @@ class GridRows extends StatelessWidget {
             controller: rowsControllerY,
             itemCount: rows.length,
             itemBuilder: (context, rowIndex) => GestureDetector(
+              // Instead of limiting the click area to child's clickable area,
+              // use complete area of widget
+              behavior: HitTestBehavior.opaque,
               onTap: rows[rowIndex].onTap?.call,
               onLongPress: rows[rowIndex].onLongPress?.call,
               child: Row(


### PR DESCRIPTION
If you add `onLongPress` callback to a `GridRow` in the example app, you will see that the callback is invoked when clicking on text but not on whitespace. This is because `behavior` defaults to `HitTestBehavior.child` when null, and thus only the text of a cell is clickable and not any whitespace of `Text`. By changing the behavior to `HitTestBehavior.opaque`, then the whole cell is clickable. `HitTestBehavior.translucent` would probably also work but I don't see any benefit of passing listening abilities down to text cell.

Assuming this should be the default behavior, if not, can had `behavior` to `GridRow`.